### PR TITLE
Multistage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 # Use base golang image from Docker Hub
-FROM golang:1.12
+FROM golang:1.12-alpine AS build
+RUN apk add --update --no-cache git
 WORKDIR /src/aws-secrets-manager
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
 RUN go build -o /app -v ./cmd/aws-secrets-manager
+
+FROM alpine
+COPY --from=build /app /.
 ENTRYPOINT ["/app"]


### PR DESCRIPTION
Using alpine and a multistage build takes this container from 962MB to
16.6 MB

Also added a .dockerignore file for layer optimization.