### PR TITLE
Make The Mount Point Name Configurable

### DIFF
--- a/cmd/aws-secrets-manager/main.go
+++ b/cmd/aws-secrets-manager/main.go
@@ -69,12 +69,16 @@ func main() {
 		writeOutput(decodedBinarySecret)
 	}
 }
+
 func writeOutput(output string) {
-	f, err := os.Create("/tmp/secret")
+  //os.Setenv("MOUNT_NAME", "CATS_N_DOGS")
+  MountName := os.Getenv("MOUNT_NAME")
+
+	f, err := os.Create("/tmp/" + MountName)
 	if err != nil {
 		return
 	}
 	defer f.Close()
-	
+
 	f.WriteString(output)
 }

--- a/kubernetes-manifests/hello.deployment.yaml
+++ b/kubernetes-manifests/hello.deployment.yaml
@@ -13,7 +13,7 @@ spec:
   containers:
   - name: myapp-container
     image: busybox:1.28
-    command: ['sh', '-c', 'echo $(cat /tmp/secret) && sleep 3600']
+    command: ['sh', '-c', 'echo $(cat /tmp/CATS_N_DOGS) && sleep 3600']
     volumeMounts:
       - name: vol
         mountPath: /tmp
@@ -25,6 +25,8 @@ spec:
         value: "us-east-1"
       - name: SECRET_NAME
         value: "catsndogs"
+      - name: MOUNT_NAME
+        value: "CATS_N_DOGS"
     volumeMounts:
       - name: vol
         mountPath: /tmp


### PR DESCRIPTION
This PR makes the mount point within the container configurable so that multiple secrets can be added to the container.

New option added: `MOUNT_NAME`
Path will be created as `/tmp/<mount name>`